### PR TITLE
Rewrite aliased file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ options = {
   aliases: {
     // Map an extension to a supported extension, e.g. `'.ts': '.js'`. The
     // aliased extension is used for module type detection, so `readModule()`
-    // must return source compatible with that type.
+    // must return source compatible with that type. Aliased modules are also
+    // emitted with the aliased extension, and resolutions to them are
+    // rewritten to match, so `'.ts': '.js'` yields a `file:///foo.js`
+    // dependency rather than `file:///foo.ts`.
   },
   resolve: resolve.default
 }

--- a/index.js
+++ b/index.js
@@ -109,6 +109,26 @@ module.exports = exports = function traverse(entry, opts, readModule, listPrefix
 exports.constants = constants
 exports.resolve = resolve
 
+exports.alias = function alias(url, opts = {}) {
+  const { aliases = null } = opts
+
+  if (aliases === null) return url
+
+  const match = url.pathname.match(/\.[a-z]+$/)
+
+  if (match === null) return url
+
+  const [extension] = match
+
+  if (extension in aliases === false) return url
+
+  url = new URL(url)
+
+  url.pathname = url.pathname.slice(0, -extension.length) + aliases[extension]
+
+  return url
+}
+
 exports.module = function* (url, source, attributes, artifacts, visited, opts = {}) {
   const { resolutions = null, defaultType = constants.SCRIPT, aliases = null } = opts
 
@@ -242,7 +262,12 @@ exports.module = function* (url, source, attributes, artifacts, visited, opts = 
   }
 
   yield {
-    dependency: { url, source, imports: compressImportsMap(imports), lexer }
+    dependency: {
+      url: exports.alias(url, opts),
+      source,
+      imports: compressImportsMap(imports),
+      lexer
+    }
   }
 
   return true
@@ -317,7 +342,7 @@ exports.preresolved = function* (url, source, resolutions, artifacts, visited, o
 
   yield {
     dependency: {
-      url,
+      url: exports.alias(url, opts),
       source,
       imports: compressImportsMap(imports),
       lexer: { imports: [] }
@@ -421,7 +446,7 @@ exports.imports = function* (parentURL, source, imports, artifacts, lexer, visit
           const source = yield { module: url }
 
           if (source !== null) {
-            addResolution(imports, specifier, matchedConditions, url)
+            addResolution(imports, specifier, matchedConditions, exports.alias(url, opts))
 
             let attributes = entry.attributes
 

--- a/test.js
+++ b/test.js
@@ -1833,10 +1833,10 @@ test('aliases, .ts to .js', (t) => {
 
   t.alike(result.values, [
     {
-      url: new URL('file:///foo.ts'),
+      url: new URL('file:///foo.js'),
       source: "const bar = require('./bar.ts')",
       imports: {
-        './bar.ts': 'file:///bar.ts'
+        './bar.ts': 'file:///bar.js'
       },
       lexer: {
         imports: [
@@ -1851,7 +1851,7 @@ test('aliases, .ts to .js', (t) => {
       }
     },
     {
-      url: new URL('file:///bar.ts'),
+      url: new URL('file:///bar.js'),
       source: 'module.exports = 42',
       imports: {},
       lexer: { imports: [] }
@@ -1878,10 +1878,10 @@ test('aliases, .mts to .mjs', (t) => {
 
   t.alike(result.values, [
     {
-      url: new URL('file:///foo.mts'),
+      url: new URL('file:///foo.mjs'),
       source: "import './bar.mts'",
       imports: {
-        './bar.mts': 'file:///bar.mts'
+        './bar.mts': 'file:///bar.mjs'
       },
       lexer: {
         imports: [
@@ -1896,7 +1896,7 @@ test('aliases, .mts to .mjs', (t) => {
       }
     },
     {
-      url: new URL('file:///bar.mts'),
+      url: new URL('file:///bar.mjs'),
       source: 'export default 42',
       imports: {},
       lexer: { imports: [] }
@@ -1930,10 +1930,10 @@ test('aliases, .ts to .js with defaultType MODULE', (t) => {
 
   t.alike(result.values, [
     {
-      url: new URL('file:///foo.ts'),
+      url: new URL('file:///foo.js'),
       source: "import './bar.ts'",
       imports: {
-        './bar.ts': 'file:///bar.ts'
+        './bar.ts': 'file:///bar.js'
       },
       lexer: {
         imports: [
@@ -1948,7 +1948,7 @@ test('aliases, .ts to .js with defaultType MODULE', (t) => {
       }
     },
     {
-      url: new URL('file:///bar.ts'),
+      url: new URL('file:///bar.js'),
       source: 'export default 42',
       imports: {},
       lexer: { imports: [] }


### PR DESCRIPTION
Without rewriting the extensions to match their alias, the type of the rewritten modules could not be determined at runtime as they were still using the original extensions.