### PR TITLE
Audit the workflows on every change

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 jobs:
+  security:
+    runs-on: ubuntu-latest
+    name: Security
+    steps:
+      - uses: holepunchto/actions/security-base@v1
   lint:
     runs-on: ubuntu-latest
     name: Lint


### PR DESCRIPTION
Rolls out the `security` step from holepunchto/actions, which runs zizmor over the workflows on every change.

It is worth having: the same audit found `id-token: write` and `contents: write` declared at workflow level in 70 repos, so every build job inherited OIDC minting outside the npm environment gate. That came from the workflow in holepunchto/repo-template, which shows no symptom itself because it has a single job. Fixed across the affected repos since.

If this arrives red, the findings are the point - a fix PR lands ahead of it rather than anything being suppressed.
